### PR TITLE
Fix for OpenMDAO 3.37.0

### DIFF
--- a/dymos/phase/test/test_add_boundary_constraint.py
+++ b/dymos/phase/test/test_add_boundary_constraint.py
@@ -8,50 +8,12 @@ from openmdao.utils.assert_utils import assert_near_equal
 from dymos.utils.misc import om_version
 
 import dymos as dm
-
-
-class BrachistochroneVectorStatesODE(om.ExplicitComponent):
-    def initialize(self):
-        self.options.declare('num_nodes', types=int)
-
-    def setup(self):
-        nn = self.options['num_nodes']
-
-        self.add_input('v', val=np.zeros(nn), desc='velocity', units='m/s')
-        self.add_input('g', val=9.80665 * np.ones(nn), desc='grav. acceleration', units='m/s/s')
-        self.add_input('theta', val=np.zeros(nn), desc='angle of wire', units='rad')
-
-        self.add_output('pos_dot', val=np.zeros((nn, 2)), desc='velocity components', units='m/s')
-        self.add_output('vdot', val=np.zeros(nn), desc='acceleration magnitude', units='m/s**2')
-        self.add_output('check', val=np.zeros(nn), desc='check solution: v/sin(theta) = constant', units='m/s')
-
-        # Setup partials
-        arange = np.arange(self.options['num_nodes'])
-
-        self.declare_partials(of='vdot', wrt='g', rows=arange, cols=arange)
-        self.declare_partials(of='vdot', wrt='theta', rows=arange, cols=arange)
-
-        self.declare_coloring(wrt='*', method='cs', show_sparsity=False)
-
-    def compute(self, inputs, outputs):
-        theta = inputs['theta']
-        cos_theta = np.cos(theta)
-        sin_theta = np.sin(theta)
-        g = inputs['g']
-        v = inputs['v']
-
-        outputs['vdot'] = g * cos_theta
-        outputs['pos_dot'][:, 0] = v * sin_theta
-        outputs['pos_dot'][:, 1] = -v * cos_theta
-
-        outputs['check'] = v / sin_theta
+from dymos.examples.brachistochrone.brachistochrone_vector_states_ode import BrachistochroneVectorStatesODE
 
 
 @use_tempdirs
 class TestAddBoundaryConstraint(unittest.TestCase):
 
-    @unittest.skipIf(om_version()[0] >= (3, 36, 1) and om_version()[0] < (3, 37, 0),
-                     reason='Test is broken in OpenMDAO 3.37.0 interim development.')
     @require_pyoptsparse(optimizer='SLSQP')
     def test_simple_no_exception(self):
         p = om.Problem(model=om.Group())
@@ -91,7 +53,7 @@ class TestAddBoundaryConstraint(unittest.TestCase):
                           continuity=True, rate_continuity=True,
                           units='deg', lower=0.01, upper=179.9)
 
-        phase.add_parameter('g', units='m/s**2', val=9.80665, opt=False)
+        phase.add_parameter('g', units='m/s**2', val=9, opt=False)
 
         # Minimize time at the end of the phase
         phase.add_objective('time', loc='final', scaler=10)
@@ -251,3 +213,7 @@ class TestAddBoundaryConstraint(unittest.TestCase):
 
         expected = 'Cannot add new final boundary constraint for variable `pos` and indices None. One already exists.'
         self.assertEqual(expected, str(e.exception))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
### Summary

Fixed a test that was using an incomplete ODE definition that declared partials but didn't bother populating them.

Removed this ODE declaration in favor of the full one from elsewhere in the examples.

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
